### PR TITLE
Add realtor header to buyer report

### DIFF
--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -10,6 +10,7 @@ import BuyerCriteriaForm from "@/components/buyer-report/buyer-criteria-form"
 import ListingsForm from "@/components/buyer-report/listings-form"
 import RealtorNotesForm from "@/components/buyer-report/realtor-notes-form"
 import ComparisonReport from "@/components/buyer-report/comparison-report"
+import RealtorHeader from "@/components/buyer-report/realtor-header"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -232,6 +233,7 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
                 </CardTitle>
               </CardHeader>
               <CardContent className="flex-grow flex flex-col overflow-hidden">
+                <RealtorHeader reportData={reportData} />
                 <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full flex-grow flex flex-col">
                   <TabsList className="grid w-full grid-cols-2 mb-4 shrink-0">
                     <TabsTrigger

--- a/components/buyer-report/realtor-header.tsx
+++ b/components/buyer-report/realtor-header.tsx
@@ -1,0 +1,49 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { getContrastingTextColor } from "@/lib/utils"
+import type { BuyerReportState } from "@/lib/buyer-report-types"
+
+interface RealtorHeaderProps {
+  reportData: BuyerReportState
+}
+
+export default function RealtorHeader({ reportData }: RealtorHeaderProps) {
+  const {
+    preparedBy,
+    realtorAgency,
+    realtorPhoto,
+    realtorLat,
+    realtorLng,
+    primaryColor,
+    secondaryColor,
+  } = reportData
+
+  const bgColor = primaryColor || "transparent"
+  const textColor = secondaryColor || getContrastingTextColor(primaryColor)
+
+  const coordsAvailable =
+    typeof realtorLat === "number" &&
+    typeof realtorLng === "number" &&
+    isFinite(realtorLat) &&
+    isFinite(realtorLng)
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-md mb-4 p-4"
+      style={{ backgroundColor: bgColor, color: textColor }}
+    >
+      <Avatar className="h-16 w-16">
+        <AvatarImage src={realtorPhoto || "/placeholder-user.jpg"} alt={preparedBy || "Realtor"} />
+        <AvatarFallback>{preparedBy ? preparedBy.charAt(0) : "R"}</AvatarFallback>
+      </Avatar>
+      <div className="flex flex-col">
+        <span className="text-lg font-semibold">{preparedBy || "Realtor Name"}</span>
+        <span className="text-sm">{realtorAgency || "Agency"}</span>
+        {coordsAvailable && (
+          <span className="text-xs">
+            {realtorLat?.toFixed(4)}, {realtorLng?.toFixed(4)}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/buyer-report-types.ts
+++ b/lib/buyer-report-types.ts
@@ -39,6 +39,9 @@ export interface BuyerReportState {
   preparedDate: string
   preparedBy: string
   realtorAgency: string
+  realtorPhoto?: string
+  realtorLat?: number
+  realtorLng?: number
   primaryColor?: string
   secondaryColor?: string
   buyerCriteria: BuyerCriteria
@@ -78,6 +81,9 @@ export const initialBuyerReportState: BuyerReportState = {
   preparedDate: new Date().toLocaleDateString("en-CA"),
   preparedBy: "",
   realtorAgency: "",
+  realtorPhoto: "",
+  realtorLat: undefined,
+  realtorLng: undefined,
   buyerCriteria: {
     priceRange: { min: "", max: "" },
     beds: "",


### PR DESCRIPTION
## Summary
- add optional realtor photo and coordinates to buyer report state
- show realtor header in preview panel

## Testing
- `yarn lint` *(fails: prompts to configure ESLint)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685d72eb1dcc832e9c6c6ac478c2584b