### PR TITLE
Normalize realtor profile colors

### DIFF
--- a/app/api/analyze-realtor-url/route.ts
+++ b/app/api/analyze-realtor-url/route.ts
@@ -114,12 +114,15 @@ export async function POST(req: NextRequest) {
     const normalizeColor = (color?: string): string | undefined => {
       if (!color) return undefined
       const trimmed = color.trim().toLowerCase()
-      if (parseCssColor(trimmed)) return color
-      return colorMap[trimmed] ?? color
+      // If already a valid CSS color string, use the sanitized value
+      if (parseCssColor(trimmed)) return trimmed
+      // Otherwise fall back to a mapped name or keep the sanitized string
+      return colorMap[trimmed] ?? trimmed
     }
 
     const normalizedPrimary = normalizeColor(extractedProfile.primaryColor)
     const normalizedSecondary = normalizeColor(extractedProfile.secondaryColor)
+    // Store normalized colors so downstream consumers receive consistent CSS values
 
     // 4. Save to Supabase
     // Optional: Check if a user is authenticated if your table uses user_id

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -58,7 +58,7 @@ export function getContrastingTextColor(color?: string): string {
   return hsp > 127.5 ? "#000000" : "#FFFFFF" // Threshold can be adjusted
 }
 
-function parseCssColor(color?: string): [number, number, number] | null {
+export function parseCssColor(color?: string): [number, number, number] | null {
   if (!color) return null
 
   let hex = color.replace(/^#/, "")

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -58,6 +58,7 @@ export function getContrastingTextColor(color?: string): string {
   return hsp > 127.5 ? "#000000" : "#FFFFFF" // Threshold can be adjusted
 }
 
+// Exported so API routes can validate and normalize colors returned by the LLM
 export function parseCssColor(color?: string): [number, number, number] | null {
   if (!color) return null
 


### PR DESCRIPTION
## Summary
- export `parseCssColor` from util library
- validate and normalize colors scraped from realtor websites

## Testing
- `CI=1 yarn lint` *(fails: unescaped entities)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f3bb7c4832e8f135464693ac2dc