### PR TITLE
Restore color normalization utilities

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -69,7 +69,7 @@ export function normalizeColorToHex(color?: string): string | null {
     .padStart(2, "0")}${b.toString(16).padStart(2, "0")}`
 }
 
-function parseCssColor(color?: string): [number, number, number] | null {
+export function parseCssColor(color?: string): [number, number, number] | null {
   if (!color) return null
 
   let hex = color.replace(/^#/, "")


### PR DESCRIPTION
## Summary
- export `parseCssColor` in utils for API route usage
- keep `normalizeColorToHex` available above it

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d8634df00832eac861c4492f9f46d