### PR TITLE
Unify button styles

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -138,7 +138,6 @@ export default function HomePage() {
                 <Button
                   onClick={handleAnalyzeAndSaveUrl}
                   type="button"
-                  className="bg-sky-700 hover:bg-sky-600 text-gray-100 px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center"
                   disabled={isLoading}
                 >
                   {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
@@ -211,10 +210,7 @@ export default function HomePage() {
             {/* Proceed Buttons Section */}
             {canProceed && (
               <div className="flex flex-col sm:flex-row justify-center items-center gap-6">
-                <Button
-                  asChild
-                  className="bg-sky-700 hover:bg-sky-600 text-gray-100 px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center w-full sm:w-auto"
-                >
+                <Button asChild className="w-full sm:w-auto">
                   <Link href="/buyer-report" className="flex items-center">
                     For my Buyer
                     <UsersIcon className="ml-2 h-5 w-5" />
@@ -222,7 +218,7 @@ export default function HomePage() {
                 </Button>
                 <Button
                   asChild
-                  className="bg-sky-700 hover:bg-sky-600 text-gray-100 px-6 py-2.5 rounded-md text-sm font-medium transition-colors flex items-center w-full sm:w-auto"
+                  className="w-full sm:w-auto"
                 >
                   <Link href="/cma-report" className="flex items-center">
                     For my Seller

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,18 +9,15 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        default: "bg-sky-700 text-gray-100 hover:bg-sky-600",
+        destructive: "bg-sky-700 text-gray-100 hover:bg-sky-600",
+        outline: "bg-sky-700 text-gray-100 hover:bg-sky-600",
+        secondary: "bg-sky-700 text-gray-100 hover:bg-sky-600",
+        ghost: "bg-sky-700 text-gray-100 hover:bg-sky-600",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
+        default: "px-6 py-2.5",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",


### PR DESCRIPTION
## Summary
- use the Analyze button style for all variant options
- remove custom classes from Home page buttons

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685d9ec6f548832eb478d51dfe81298f