### PR TITLE
Rename buyer-report route

### DIFF
--- a/app/cma-ai-gen/page.tsx
+++ b/app/cma-ai-gen/page.tsx
@@ -1,6 +1,6 @@
 import BuyerReportClientPage from "@/components/buyer-report/buyer-report-client-page"
 
-export default function BuyerReportRoutePage() {
+export default function CmaAiGenRoutePage() {
   const googleMapsApiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
 
   return <BuyerReportClientPage googleMapsApiKey={googleMapsApiKey} />

--- a/app/cma-report/page.tsx
+++ b/app/cma-report/page.tsx
@@ -258,7 +258,7 @@ export default function CmaToolRoutePage() {
         <Card className={cn("print:hidden", cardClassName)}>
           <CardFooter className="flex justify-center p-6">
             <Button asChild variant="outline" style={primaryColorStyle}>
-              <Link href="/buyer-report">
+              <Link href="/cma-ai-gen">
                 <Edit3Icon className="mr-2 h-4 w-4" /> Edit Buyer Report
               </Link>
             </Button>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -215,7 +215,7 @@ export default function HomePage() {
             {canProceed && (
               <div className="flex flex-col sm:flex-row justify-center items-center gap-6">
                 <Button asChild className="w-full sm:w-auto" style={{ backgroundColor: "#64CC7D", color: "#1E404B" }}>
-                  <Link href="/buyer-report" className="flex items-center">
+                  <Link href="/cma-ai-gen" className="flex items-center">
                     For my Buyer
                     <UsersIcon className="ml-2 h-5 w-5" />
                   </Link>
@@ -254,7 +254,7 @@ export default function HomePage() {
                   title: "Buyer Report Generation",
                   description:
                     "Craft detailed, client-ready reports comparing listings to buyer criteria with map views and notes.",
-                  link: "/buyer-report",
+                  link: "/cma-ai-gen",
                 },
                 {
                   icon: <BarChartIcon className="h-10 w-10 text-sky-400 mb-4" />,


### PR DESCRIPTION
## Summary
- rename route `/buyer-report` to `/cma-ai-gen`
- update the CTA buttons and feature card links to use the new `/cma-ai-gen` path
- rename the route component to `CmaAiGenRoutePage`

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685da5e9ca80832e9e5f8f9e953fb7a5