### PR TITLE
Add seller option to CMA generation

### DIFF
--- a/app/cma-ai-gen/page.tsx
+++ b/app/cma-ai-gen/page.tsx
@@ -1,7 +1,17 @@
 import BuyerReportClientPage from "@/components/buyer-report/buyer-report-client-page"
+import CmaForm from "@/components/cma/cma-form"
 
-export default function CmaAiGenRoutePage() {
+interface PageProps {
+  searchParams?: { type?: string }
+}
+
+export default function CmaAiGenRoutePage({ searchParams }: PageProps) {
   const googleMapsApiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+  const reportType = searchParams?.type === "seller" ? "seller" : "buyer"
 
-  return <BuyerReportClientPage googleMapsApiKey={googleMapsApiKey} />
+  return reportType === "seller" ? (
+    <CmaForm googleMapsApiKey={googleMapsApiKey} />
+  ) : (
+    <BuyerReportClientPage googleMapsApiKey={googleMapsApiKey} />
+  )
 }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -215,13 +215,13 @@ export default function HomePage() {
             {canProceed && (
               <div className="flex flex-col sm:flex-row justify-center items-center gap-6">
                 <Button asChild className="w-full sm:w-auto" style={{ backgroundColor: "#64CC7D", color: "#1E404B" }}>
-                  <Link href="/cma-ai-gen" className="flex items-center">
+                  <Link href="/cma-ai-gen?type=buyer" className="flex items-center">
                     For my Buyer
                     <UsersIcon className="ml-2 h-5 w-5" />
                   </Link>
                 </Button>
                 <Button asChild className="w-full sm:w-auto" style={{ backgroundColor: "#64CC7D", color: "#1E404B" }}>
-                  <Link href="/cma-report" className="flex items-center">
+                  <Link href="/cma-ai-gen?type=seller" className="flex items-center">
                     For my Seller
                     <FileText className="ml-2 h-5 w-5" />
                   </Link>

--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -136,7 +136,7 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
               <CardHeader>
                 <CardTitle className="text-xl flex items-center gap-2">
                   <ClipboardListIcon className="h-5 w-5" style={{ color: "var(--primary)" }} />
-                  Report Details
+                  Report Details (Buyer)
                 </CardTitle>
               </CardHeader>
               <CardContent>

--- a/components/cma/cma-form.tsx
+++ b/components/cma/cma-form.tsx
@@ -556,7 +556,7 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
               </div>
               <Card className={cardClassName}>
                 <CardHeader>
-                  <CardTitle className="text-xl">Report Setup</CardTitle>
+                  <CardTitle className="text-xl">Report Setup (Seller)</CardTitle>
                   <CardDescription>Basic information for your CMA report.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">


### PR DESCRIPTION
## Summary
- route both seller and buyer flows to `/cma-ai-gen`
- detect buyer vs seller in `/cma-ai-gen` via `type` query parameter
- label report detail sections as buyer or seller

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685dbac8c550832eb941b05ad9036794