### PR TITLE
Add dynamic POI input with Google geocoding

### DIFF
--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -194,7 +194,11 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className="p-3 pt-1">
-                  <BuyerCriteriaForm data={reportData} setData={setReportData} />
+                  <BuyerCriteriaForm
+                    data={reportData}
+                    setData={setReportData}
+                    googleMapsApiKey={googleMapsApiKey}
+                  />
                 </AccordionContent>
               </AccordionItem>
               <AccordionItem value="listings-management" className={`border rounded-lg shadow-sm ${cardClassName}`}>

--- a/components/buyer-report/place-autocomplete-input.tsx
+++ b/components/buyer-report/place-autocomplete-input.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useRef } from "react"
+import { Autocomplete, useJsApiLoader } from "@react-google-maps/api"
+import { Input } from "@/components/ui/input"
+
+interface PlaceAutocompleteInputProps {
+  value: string
+  onChange: (value: string) => void
+  onSelect: (address: string, place: google.maps.places.PlaceResult) => void
+  onBlur?: (value: string) => void
+  placeholder?: string
+  apiKey?: string
+}
+
+export default function PlaceAutocompleteInput({ value, onChange, onSelect, onBlur, placeholder, apiKey }: PlaceAutocompleteInputProps) {
+  const { isLoaded } = useJsApiLoader({ googleMapsApiKey: apiKey || "", libraries: ["places"] })
+  const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null)
+
+  const handleLoad = (autocomplete: google.maps.places.Autocomplete) => {
+    autocompleteRef.current = autocomplete
+  }
+
+  const handlePlaceChanged = () => {
+    const place = autocompleteRef.current?.getPlace()
+    if (place && place.formatted_address) {
+      onSelect(place.formatted_address, place)
+    }
+  }
+
+  if (!isLoaded) {
+    return <Input value={value} onChange={(e) => onChange(e.target.value)} onBlur={() => onBlur?.(value)} placeholder={placeholder} />
+  }
+
+  return (
+    <Autocomplete onLoad={handleLoad} onPlaceChanged={handlePlaceChanged}>
+      <Input value={value} onChange={(e) => onChange(e.target.value)} onBlur={() => onBlur?.(value)} placeholder={placeholder} />
+    </Autocomplete>
+  )
+}

--- a/lib/buyer-report-types.ts
+++ b/lib/buyer-report-types.ts
@@ -90,7 +90,7 @@ export const initialBuyerReportState: BuyerReportState = {
     baths: "",
     sqft: "",
     mustHaveFeatures: "",
-    pointsOfInterest: [],
+    pointsOfInterest: [createEmptyPOI()],
   },
   listings: [createEmptyListing()],
   realtorNotes: "",


### PR DESCRIPTION
## Summary
- initialize buyer reports with a blank POI entry
- add Google Places autocomplete input component
- support dynamic POI addition and removal with auto-geocoding
- pass Google Maps API key to buyer criteria form

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685dbecbc114832eaec449df208740cc