### PR TITLE
Adjust header background on CMA AI page

### DIFF
--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -29,7 +29,7 @@ import {
   Settings2Icon,
   EyeIcon,
 } from "lucide-react"
-import { getContrastingTextColor } from "@/lib/utils"
+import { getContrastingTextColor, lightenColor } from "@/lib/utils"
 
 const MapView = dynamic(() => import("@/components/buyer-report/map-view"), {
   ssr: false,
@@ -107,7 +107,13 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
         "--primary": "#1E404B",
       } as React.CSSProperties}
     >
-      <header className="sticky top-0 z-50 w-full border-b border-[#1E404B] bg-[#1E404B] mb-6 shrink-0">
+      <header
+        className="sticky top-0 z-50 w-full border-b mb-6 shrink-0"
+        style={{
+          backgroundColor: lightenColor(reportData.primaryColor || "#1E404B", 0.2),
+          borderColor: reportData.primaryColor || "#1E404B",
+        }}
+      >
         <div className="container mx-auto flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 text-white">
           <div className="flex items-center gap-3">
             <HomeIcon className="h-10 w-10" />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -115,3 +115,15 @@ export function parseCssColor(color?: string): [number, number, number] | null {
 
   return null
 }
+
+export function lightenColor(color: string, percent: number): string {
+  const rgb = parseCssColor(color)
+  if (!rgb) return color
+  const [r, g, b] = rgb
+  const newR = Math.round(r + (255 - r) * percent)
+  const newG = Math.round(g + (255 - g) * percent)
+  const newB = Math.round(b + (255 - b) * percent)
+  return `#${newR.toString(16).padStart(2, "0")}${newG
+    .toString(16)
+    .padStart(2, "0")}${newB.toString(16).padStart(2, "0")}`
+}


### PR DESCRIPTION
## Summary
- lighten CMA AI page header by 20%
- add `lightenColor` util for adjusting hex colors

## Testing
- `yarn test` *(fails: Request is not defined, Jest unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686033527afc832e84c87709408e9ba8