### PR TITLE
Fix avatar image ratio

### DIFF
--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -26,7 +26,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- prevent avatar images from stretching by adding `object-cover`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68603ee4b034832eb8b96039956fc644