### PR TITLE
Apply home theme to CMA generator

### DIFF
--- a/app/cma-ai-gen/page.tsx
+++ b/app/cma-ai-gen/page.tsx
@@ -9,9 +9,15 @@ export default function CmaAiGenRoutePage({ searchParams }: PageProps) {
   const googleMapsApiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
   const reportType = searchParams?.type === "seller" ? "seller" : "buyer"
 
-  return reportType === "seller" ? (
-    <CmaForm googleMapsApiKey={googleMapsApiKey} />
-  ) : (
-    <BuyerReportClientPage googleMapsApiKey={googleMapsApiKey} />
+  const ReportComponent =
+    reportType === "seller" ? CmaForm : BuyerReportClientPage
+
+  return (
+    <div
+      className="flex min-h-screen flex-col font-sans text-[#1E404B]"
+      style={{ background: "linear-gradient(to bottom, #F1F8FD, #EFF7FC)" }}
+    >
+      <ReportComponent googleMapsApiKey={googleMapsApiKey} />
+    </div>
   )
 }

--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -104,7 +104,7 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
       className="flex flex-col min-h-screen font-sans text-[#1E404B] p-4 sm:p-6 md:p-8"
       style={{
         background: "linear-gradient(to bottom, #F1F8FD, #EFF7FC)",
-        "--primary": "#1E404B",
+        "--primary": reportData.primaryColor || "#1E404B",
       } as React.CSSProperties}
     >
       <header

--- a/components/cma/cma-form.tsx
+++ b/components/cma/cma-form.tsx
@@ -533,7 +533,13 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col h-screen p-4 sm:p-6 md:p-8">
+      <div
+        className="flex flex-col min-h-screen font-sans text-[#1E404B] p-4 sm:p-6 md:p-8"
+        style={{
+          background: "linear-gradient(to bottom, #F1F8FD, #EFF7FC)",
+          "--primary": cmaReportData.primaryColor || "#1E404B",
+        } as React.CSSProperties}
+      >
         <header className="flex justify-between items-center mb-6 shrink-0">
           <h1 className="text-3xl font-bold flex items-center gap-3">
             <FileSignatureIcon


### PR DESCRIPTION
## Summary
- wrap `cma-ai-gen` page content in a styled container
- pick realtor primary color in buyer report page
- use primary color and gradient styling in CMA form

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68604a673160832ea02df569b527cdc8