### PR TITLE
Fix Autocomplete libraries prop

### DIFF
--- a/components/buyer-report/place-autocomplete-input.tsx
+++ b/components/buyer-report/place-autocomplete-input.tsx
@@ -14,8 +14,10 @@ interface PlaceAutocompleteInputProps {
   apiKey?: string
 }
 
+const libraries = ["places"] as const
+
 export default function PlaceAutocompleteInput({ value, onChange, onSelect, onBlur, onKeyDown, placeholder, apiKey }: PlaceAutocompleteInputProps) {
-  const { isLoaded } = useJsApiLoader({ googleMapsApiKey: apiKey || "", libraries: ["places"] })
+  const { isLoaded } = useJsApiLoader({ googleMapsApiKey: apiKey || "", libraries })
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null)
 
   const handleLoad = (autocomplete: google.maps.places.Autocomplete) => {


### PR DESCRIPTION
## Summary
- avoid recreating libraries array when loading Google Maps

## Testing
- `yarn test` *(fails: Request is not defined)*
- `yarn lint` *(fails: prompts for ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_686049e807dc832ea3cf5eba423970ca