### PR TITLE
Add marketing strategy generation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ export const metadata: Metadata = {
   title: "v0 App",
   description: "Created with v0",
   generator: "v0.dev",
+  icons: "/favicon.svg",
 }
 
 import ClientLayout from "./clientLayout"

--- a/components/cma/cma-form.tsx
+++ b/components/cma/cma-form.tsx
@@ -305,8 +305,9 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
         },
         priceAdjustmentNotes: analysis.priceAdjustmentNotes || "",
         generalNotes: analysis.generalNotes || "",
+        listingStrategy: analysis.listingStrategy || prev.listingStrategy,
       }))
-      toast({ title: "AI Analysis Generated", description: "Pricing and notes have been updated." })
+      toast({ title: "AI Analysis Generated", description: "Pricing, notes, and strategy have been updated." })
       if (!activeAccordionItems.includes("analysis-conclusion")) {
         setActiveAccordionItems((prevItems) => [...prevItems, "analysis-conclusion"])
       }
@@ -697,7 +698,7 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
                       style={{ backgroundColor: "var(--primary)", color: textColorForPrimary }}
                     >
                       <Sparkles className="h-4 w-4 mr-2" />
-                      {isAiAnalysisLoading ? "Generating..." : "Generate AI Analysis & Pricing"}
+                      {isAiAnalysisLoading ? "Generating..." : "Generate AI Analysis & Strategy"}
                     </Button>
                     <div>
                       <Label htmlFor="suggestedPriceRangeLow">Suggested Price Range (Low)</Label>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#4B7EFF"/>
+  <path d="M16 6l7 20H9l7-20z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- extend CMA AI route to generate a marketing strategy
- update CMA form to save the strategy and update button text
- add favicon metadata using a text-based icon

## Testing
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686053e0fdc8832e8a30cc204cfcb2e3