### PR TITLE
Add listing strategy options & bigger photo

### DIFF
--- a/components/cma/cma-form.tsx
+++ b/components/cma/cma-form.tsx
@@ -9,6 +9,13 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import {
   Trash2,
   PlusCircle,
   Sparkles,
@@ -26,6 +33,7 @@ import { useToast } from "@/components/ui/use-toast"
 import {
   type CmaReportDataState,
   type PropertyInput,
+  type ListingStrategy,
   initialCmaReportData,
   createEmptyPropertyInput,
 } from "@/lib/cma-types"
@@ -148,6 +156,16 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
       comparableProperties: prev.comparableProperties.map((comp) =>
         comp.id === id ? { ...comp, listingUrl: newUrl } : comp,
       ),
+    }))
+  }
+
+  const handleListingStrategyChange = (
+    field: keyof ListingStrategy,
+    value: string,
+  ) => {
+    setCmaReportData((prev) => ({
+      ...prev,
+      listingStrategy: { ...prev.listingStrategy, [field]: value },
     }))
   }
 
@@ -738,6 +756,65 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
                         placeholder="Overall market conditions, recommendations..."
                         rows={3}
                       />
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem value="listing-strategy" className={`border rounded-lg shadow-sm ${cardClassName}`}>
+                  <AccordionTrigger className="px-4 py-3 text-lg font-medium hover:no-underline data-[state=open]:border-b">
+                    <div className="flex items-center gap-2">
+                      <FileSignatureIcon className="h-5 w-5" style={{ color: "var(--primary)" }} />
+                      Strategy & Marketing
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent className="px-4 pt-2 pb-4 space-y-4">
+                    <div>
+                      <Label htmlFor="pricingStrategy">Proper Pricing</Label>
+                      <Select
+                        value={cmaReportData.listingStrategy?.pricingStrategy}
+                        onValueChange={(v) => handleListingStrategyChange("pricingStrategy", v)}
+                      >
+                        <SelectTrigger id="pricingStrategy">
+                          <SelectValue placeholder="Select option" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="Aggressive">Aggressive</SelectItem>
+                          <SelectItem value="Balanced">Balanced</SelectItem>
+                          <SelectItem value="Top of Market">Top of Market</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label htmlFor="goToMarketStrategy">Go To Market Strategy</Label>
+                      <Select
+                        value={cmaReportData.listingStrategy?.goToMarketStrategy}
+                        onValueChange={(v) => handleListingStrategyChange("goToMarketStrategy", v)}
+                      >
+                        <SelectTrigger id="goToMarketStrategy">
+                          <SelectValue placeholder="Select option" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="Immediate">Immediate</SelectItem>
+                          <SelectItem value="Delayed">Delayed</SelectItem>
+                          <SelectItem value="Preview Only">Preview Only</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label htmlFor="marketingStrategy">Marketing Strategy</Label>
+                      <Select
+                        value={cmaReportData.listingStrategy?.marketingStrategy}
+                        onValueChange={(v) => handleListingStrategyChange("marketingStrategy", v)}
+                      >
+                        <SelectTrigger id="marketingStrategy">
+                          <SelectValue placeholder="Select option" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="Digital First">Digital First</SelectItem>
+                          <SelectItem value="Traditional">Traditional</SelectItem>
+                          <SelectItem value="Hybrid">Hybrid</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                   </AccordionContent>
                 </AccordionItem>

--- a/components/cma/realtor-header.tsx
+++ b/components/cma/realtor-header.tsx
@@ -14,7 +14,7 @@ export default function RealtorHeader({ reportData }: RealtorHeaderProps) {
 
   return (
     <div className="flex items-center gap-4 rounded-md mb-4 p-4" style={{ backgroundColor: bgColor, color: textColor }}>
-      <Avatar className="h-16 w-16">
+      <Avatar className="h-[5.2rem] w-[5.2rem]">
         <AvatarImage src={realtorPhoto || "/placeholder-user.jpg"} alt={preparedBy || "Realtor"} />
         <AvatarFallback>{preparedBy ? preparedBy.charAt(0) : "R"}</AvatarFallback>
       </Avatar>

--- a/components/cma/report-sections/listing-strategy-section.tsx
+++ b/components/cma/report-sections/listing-strategy-section.tsx
@@ -14,6 +14,21 @@ export default function ListingStrategySection({ strategy }: ListingStrategySect
         <CardDescription>How to position and market your property for optimal results.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        {strategy?.pricingStrategy && (
+          <p className="text-sm">
+            <strong>Pricing Strategy:</strong> {strategy.pricingStrategy}
+          </p>
+        )}
+        {strategy?.goToMarketStrategy && (
+          <p className="text-sm">
+            <strong>Go to Market:</strong> {strategy.goToMarketStrategy}
+          </p>
+        )}
+        {strategy?.marketingStrategy && (
+          <p className="text-sm">
+            <strong>Marketing Strategy:</strong> {strategy.marketingStrategy}
+          </p>
+        )}
         <div>
           <h4 className="font-semibold text-md mb-1 flex items-center">
             <LightbulbIcon className="h-4 w-4 mr-2 text-primary" />

--- a/lib/cma-types.ts
+++ b/lib/cma-types.ts
@@ -89,6 +89,9 @@ export interface ListingStrategy {
     videoTour?: boolean
     other?: string[]
   }
+  pricingStrategy?: "Aggressive" | "Balanced" | "Top of Market"
+  goToMarketStrategy?: "Immediate" | "Delayed" | "Preview Only"
+  marketingStrategy?: "Digital First" | "Traditional" | "Hybrid"
 }
 
 export interface NetProceedsItem {
@@ -184,6 +187,9 @@ export const initialCmaReportData: CmaReportDataState = {
     priceNarrative: "Positioned competitively based on recent sales and current market conditions.",
     keySellingPoints: [],
     marketingPlan: { mls: true, socialMedia: true, openHouse: false, videoTour: false },
+    pricingStrategy: "Balanced",
+    goToMarketStrategy: "Immediate",
+    marketingStrategy: "Digital First",
   },
   netProceedsProjection: { items: [] },
   nextStepsTimeline: [


### PR DESCRIPTION
## Summary
- enlarge realtor avatar
- extend `ListingStrategy` with pricing/go-to-market/marketing options
- expose new fields in initial CMA data
- show strategies in listing strategy report section
- add drop-downs in CMA seller configurator for the new strategy fields

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68609a92754c832e9d40de624d9516b2