### PR TITLE
Rename Manage Listings section

### DIFF
--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -206,7 +206,7 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
                 <AccordionTrigger className="text-lg font-semibold p-3 hover:no-underline data-[state=open]:border-b">
                   <div className="flex items-center gap-2">
                     <ListChecksIcon className="h-5 w-5" style={{ color: "var(--primary)" }} />
-                    Step 2: Manage Listings
+                    Step 2: Comparable Listings
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className="p-3 pt-1">

--- a/components/buyer-report/comparison-report.tsx
+++ b/components/buyer-report/comparison-report.tsx
@@ -308,7 +308,7 @@ export default function ComparisonReport({ data, googleMapsApiKey, cardClassName
               <BuildingIcon className="w-16 h-16 mx-auto mb-4 text-slate-400 dark:text-slate-500" />
               <p className="text-lg font-medium mb-1">No Listings Added Yet</p>
               <p className="text-sm">
-                Please use "Step 2: Add & Manage Listings" in the left panel to include properties for comparison.
+                Please use "Step 2: Comparable Listings" in the left panel to include properties for comparison.
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- rename "Manage Listings" step to "Comparable Listings"
- update reference in comparison report

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6860b4a1040c832e98d7a4a04ff08254