### PR TITLE
Fix analyze realtor URL tests

### DIFF
--- a/__tests__/api/analyze-realtor-url.test.ts
+++ b/__tests__/api/analyze-realtor-url.test.ts
@@ -17,13 +17,13 @@ describe("/api/analyze-realtor-url", () => {
     const data = await response.json()
 
     expect(response.status).toBe(400)
-    expect(data.error).toBe("URL is required")
+    expect(data.error).toBe("Realtor URL is required")
   })
 
   it("returns error for invalid URL", async () => {
     const request = new NextRequest("http://localhost:3000/api/analyze-realtor-url", {
       method: "POST",
-      body: JSON.stringify({ url: "invalid-url" }),
+      body: JSON.stringify({ realtorUrl: "invalid-url" }),
     })
 
     const response = await POST(request)


### PR DESCRIPTION
## Summary
- use `realtorUrl` in request bodies
- update missing URL error expectation

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6860b5aaa81c832ea126d3f9ff0031fc