### PR TITLE
Standardize buttons and support Enter key on home URL

### DIFF
--- a/app/cma-report/page.tsx
+++ b/app/cma-report/page.tsx
@@ -107,7 +107,7 @@ export default function CmaToolRoutePage() {
             Home
           </Button>
         </Link>
-        <Button variant="outline" onClick={handlePrint} style={primaryColorStyle}>
+        <Button variant="outline" onClick={handlePrint}>
           <PrinterIcon className="mr-2 h-4 w-4" />
           Print Report
         </Button>
@@ -257,7 +257,7 @@ export default function CmaToolRoutePage() {
 
         <Card className={cn("print:hidden", cardClassName)}>
           <CardFooter className="flex justify-center p-6">
-            <Button asChild variant="outline" style={primaryColorStyle}>
+            <Button asChild variant="outline">
               <Link href="/cma-ai-gen">
                 <Edit3Icon className="mr-2 h-4 w-4" /> Edit Buyer Report
               </Link>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -161,13 +161,18 @@ export default function HomePage() {
                         placeholder="https://your-realtor-website.com"
                         value={realtorUrl}
                         onChange={(e) => setRealtorUrl(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault()
+                            handleAnalyzeAndSaveUrl()
+                          }
+                        }}
                         className="flex-1"
                         disabled={isAnalyzing}
                       />
                       <Button
                         onClick={handleAnalyzeAndSaveUrl}
                         disabled={isAnalyzing || !realtorUrl.trim()}
-                        className="bg-[#1E404B] hover:bg-[#1E404B]/90 text-white"
                       >
                         {isAnalyzing ? (
                           <>
@@ -225,16 +230,13 @@ export default function HomePage() {
                       </div>
                       <div className="mt-4 flex space-x-2">
                         <Link href="/cma-ai-gen?type=buyer">
-                          <Button className="bg-[#64CC7D] hover:bg-[#64CC7D]/90 text-white">
+                          <Button>
                             <FileText className="mr-2 h-4 w-4" />
                             Buyer
                           </Button>
                         </Link>
                         <Link href="/cma-ai-gen?type=seller">
-                          <Button
-                            variant="outline"
-                            className="border-[#1E404B] text-[#1E404B] hover:bg-[#1E404B]/10 bg-transparent"
-                          >
+                          <Button variant="outline">
                             <BarChart3 className="mr-2 h-4 w-4" />
                             Seller
                           </Button>
@@ -320,7 +322,7 @@ export default function HomePage() {
               </div>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Link href="/cma-ai-gen">
-                  <Button className="bg-[#64CC7D] hover:bg-[#64CC7D]/90 text-white">
+                  <Button>
                     <FileText className="mr-2 h-4 w-4" />
                     Create Your First Report
                     <ArrowRight className="ml-2 h-4 w-4" />

--- a/components/buyer-report/buyer-report-client-page.tsx
+++ b/components/buyer-report/buyer-report-client-page.tsx
@@ -95,7 +95,6 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
 
   const inactiveTabStyle = reportData.secondaryColor ? { color: textColorForSecondary } : {}
 
-  const generateReportButtonStyle = { backgroundColor: "#64CC7D", color: "#1E404B" }
 
   const cardClassName = reportData.secondaryColor ? "bg-card/80 backdrop-blur-sm" : "bg-card"
 
@@ -124,7 +123,7 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
               </p>
             </div>
           </div>
-          <Button asChild className="shrink-0" style={{ backgroundColor: "#64CC7D", color: "#1E404B" }}>
+          <Button asChild className="shrink-0">
             <Link href="/home">
               <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
             </Link>
@@ -279,7 +278,6 @@ export default function BuyerReportClientPage({ googleMapsApiKey }: BuyerReportC
               <Button
                 asChild
                 size="lg"
-                style={generateReportButtonStyle}
                 className="px-10 py-6 text-lg shadow-lg hover:shadow-xl transition-shadow"
               >
                 <Link href="/cma-report">

--- a/components/buyer-report/comparison-report.tsx
+++ b/components/buyer-report/comparison-report.tsx
@@ -284,8 +284,7 @@ export default function ComparisonReport({ data, googleMapsApiKey, cardClassName
                           asChild
                           variant="outline"
                           size="sm"
-                          className="w-full mt-4 border-primary/30 text-primary hover:bg-primary/5 hover:text-primary"
-                          style={{ borderColor: primaryColor ? `${primaryColor}66` : undefined, color: primaryColor }}
+                          className="w-full mt-4"
                         >
                           <a
                             href={clickableStreetViewUrl}

--- a/components/buyer-report/realtor-notes-form.tsx
+++ b/components/buyer-report/realtor-notes-form.tsx
@@ -54,7 +54,6 @@ export default function RealtorNotesForm({ data, setData }: RealtorNotesFormProp
     }
   }
 
-  const buttonStyle = data.primaryColor ? { backgroundColor: data.primaryColor } : {}
 
   return (
     <Card>
@@ -69,7 +68,7 @@ export default function RealtorNotesForm({ data, setData }: RealtorNotesFormProp
         <div className="grid w-full gap-2">
           <div className="flex justify-between items-center">
             <Label htmlFor="realtorNotes">Your Notes</Label>
-            <Button onClick={handleGenerateRecommendation} disabled={isLoading} size="sm" style={buttonStyle}>
+            <Button onClick={handleGenerateRecommendation} disabled={isLoading} size="sm">
               {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Sparkles className="mr-2 h-4 w-4" />}
               Generate with AI
             </Button>

--- a/components/cma/cma-form.tsx
+++ b/components/cma/cma-form.tsx
@@ -688,7 +688,6 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
                       onClick={handleGenerateAiAnalysis}
                       disabled={isAiAnalysisLoading || !hasSubjectDetails || comparableDetailsCount === 0}
                       className="w-full mb-2"
-                      style={{ backgroundColor: "var(--primary)", color: textColorForPrimary }}
                     >
                       <Sparkles className="h-4 w-4 mr-2" />
                       {isAiAnalysisLoading ? "Generating..." : "Generate AI Analysis & Pricing"}
@@ -753,15 +752,6 @@ export default function CmaForm({ initialDataProp, googleMapsApiKey }: CmaFormPr
                 <Button
                   variant="outline"
                   onClick={() => typeof window !== "undefined" && window.print()}
-                  style={{ borderColor: "var(--primary)", color: "var(--primary)" }}
-                  onMouseOver={(e) => {
-                    e.currentTarget.style.backgroundColor = "var(--primary)"
-                    e.currentTarget.style.color = textColorForPrimary
-                  }}
-                  onMouseOut={(e) => {
-                    e.currentTarget.style.backgroundColor = "transparent"
-                    e.currentTarget.style.color = "var(--primary)"
-                  }}
                 >
                   Print Report
                 </Button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,11 +9,12 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-sky-700 text-gray-100 hover:bg-sky-600",
-        destructive: "bg-sky-700 text-gray-100 hover:bg-sky-600",
-        outline: "bg-sky-700 text-gray-100 hover:bg-sky-600",
-        secondary: "bg-sky-700 text-gray-100 hover:bg-sky-600",
-        ghost: "bg-sky-700 text-gray-100 hover:bg-sky-600",
+        default: "bg-[#64CC7D] text-[#1E404B] hover:bg-[#64CC7D]/90",
+        destructive: "bg-[#64CC7D] text-[#1E404B] hover:bg-[#64CC7D]/90",
+        outline:
+          "border border-[#1E404B] text-[#1E404B] bg-transparent hover:bg-[#64CC7D]/10",
+        secondary: "bg-[#64CC7D] text-[#1E404B] hover:bg-[#64CC7D]/90",
+        ghost: "bg-[#64CC7D] text-[#1E404B] hover:bg-[#64CC7D]/90",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## Summary
- enable pressing Enter to analyze home page URL
- standardize button colors across the app

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68616cd82500832e8c5a71be4bb40572